### PR TITLE
ignore python deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "automerge": false,
-  "ignoreDeps": ["docker"],
+  "ignoreDeps": ["python"],
   "labels": ["renovate"],
   "schedule": ["after 3pm and before 7pm"],
   "timezone": "Asia/Tokyo"


### PR DESCRIPTION
Python version in this project depends on the python runtime version in Vercel.
ref. https://vercel.com/docs/runtimes#official-runtimes/python/python-version