### PR TITLE
bump Python version to 3.9.8 along with Vercel

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.6.15-slim
+FROM python:3.9.8-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
See https://vercel.com/docs/runtimes#official-runtimes/python/python-version